### PR TITLE
Preserve also the time scale from the image layers

### DIFF
--- a/src/iterseg/segmentation.py
+++ b/src/iterseg/segmentation.py
@@ -760,9 +760,10 @@ def segmentation_wrapper(
     # Prepare data
     # ------------
     shape_4D = np.broadcast_shapes((1,) * 4, input_volume_layer.data.shape)
+    ndim = len(shape_4D)
     data = np.reshape(input_volume_layer.data, shape_4D)
-    scale = viewer.layers[0].scale[-3:] # lazy assumption that all layers have the same scale 
-    translate = viewer.layers[0].translate[-3:] # and same translate 
+    scale = viewer.layers[0].scale[-ndim:]  # lazy assumption that all layers have the same scale
+    translate = viewer.layers[0].translate[-ndim:]  # and same translate
     ndim = len(chunk_size)
 
     # Output labels


### PR DESCRIPTION
When the time scale on the layers is not 1, as is the case in the ome data
because the correct scale in seconds is set, the added labels layer is not
aligned in time, which results in weird behaviour with the napari slider, and
the segmented time points not lining up with the corresponding segmented image.
This PR fixes that issue.
